### PR TITLE
Use exec to launch supervisord

### DIFF
--- a/scripts/start_valhalla.sh
+++ b/scripts/start_valhalla.sh
@@ -21,4 +21,4 @@ export PRIME_PROXY=$(jq -r ".loki.service.proxy" conf/valhalla.json)_in
 export PRIME_LOOPBACK=$(jq -r ".httpd.service.loopback" conf/valhalla.json)
 export PRIME_INTERRUPT=$(jq -r ".httpd.service.interrupt" conf/valhalla.json)
 
-/usr/bin/supervisord -n -c /conf/supervisord.conf
+exec /usr/bin/supervisord -n -c /conf/supervisord.conf


### PR DESCRIPTION
This way signals sent to the docker are forwarded directly to
supervisord, aka you can ctrl-c it :)