### PR TITLE
Gk traffic

### DIFF
--- a/Dockerfile-ppa
+++ b/Dockerfile-ppa
@@ -12,6 +12,7 @@ RUN apt-get install \
       osmosis \
       osmctools \
       pigz \
+      parallel \
       awscli \
       supervisor \
       software-properties-common \

--- a/Dockerfile-source
+++ b/Dockerfile-source
@@ -12,6 +12,7 @@ RUN apt-get install \
       osmosis \
       osmctools \
       pigz \
+      parallel \
       awscli \
       supervisor \
       software-properties-common \

--- a/scripts/batch.sh
+++ b/scripts/batch.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+which parallel &> /dev/null
+if [ $? != 0 ]; then
+	echo "parallel is required please install it"
+	echo "sudo apt-get install parallel"
+	exit 1
+fi
+
+function usage() {
+        echo "Usage: $0 route_request_file conf [concurrency] [outDir]"
+        echo "Example: $0 requests/demo_routes.txt"
+        echo "Example: $0 requests/demo_routes.txt ~/valhalla.json"
+        echo "Example: $0 requests/demo_routes.txt ~/valhalla.json 8"
+        echo "Example: $0 requests/demo_routes.txt ~/valhalla.json 8 my_special_dir"
+        exit 1
+}
+
+#set the input file
+if [ -z "${1}" ]; then
+	usage
+elif [ ! -f "${1}" ]; then
+	usage
+else
+	INPUT="${1}"
+fi
+
+#set config file
+CONF="${2}"
+
+#how many threads do you want, default to max
+CONCURRENCY=$(nproc)
+if [ "${3}" ]; then
+	CONCURRENCY="${3}"
+fi
+
+#where do you want the output, default to current time
+OUTDIR=$(date +%Y%m%d_%H%M%S)_$(basename "${INPUT%.*}")
+if [ "${4}" ]; then
+	OUTDIR="${4}"
+fi
+RESULTS_OUTDIR="results/${OUTDIR}"
+mkdir -p "${RESULTS_OUTDIR}"
+
+#turn the nice input into something parallel can parse for args
+TMP="$(mktemp)"
+cp -rp "${INPUT}" "${TMP}"
+for arg in $(valhalla_run_route --help | grep -o '\-[a-z\-]\+' | sort | uniq); do
+	sed -i -e "s/[ ]\?${arg}[ ]\+/|${arg}|/g" "${TMP}"
+done
+sed -i -e "s;$;|--config|${CONF};g" -e "s/\([^\\]\)'|/\1|/g" -e "s/|'/|/g" "${TMP}"
+
+#run all of the paths, make sure to cut off the timestamps
+#from the log messages otherwise every line will be a diff
+#TODO: add leading zeros to output files so they sort nicely
+echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${OUTDIR}\x1b[0m"
+cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "valhalla_run_route {} 2>&1 | grep -F STATISTICS | sed -e 's/.* //g' > ${RESULTS_OUTDIR}/{#}_statistics.csv"
+rm -f "${TMP}"
+echo "orgLat, orgLng, destLat, destLng, result, #Passes, runtime, trip time, length, arcDistance, #Manuevers" > ${RESULTS_OUTDIR}/statistics.csv
+cat `ls -1v ${RESULTS_OUTDIR}/*_statistics.csv` >> ${RESULTS_OUTDIR}/statistics.csv

--- a/scripts/cut_tiles.sh
+++ b/scripts/cut_tiles.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+export DATA_DIR=${DATA_DIR:-"/data/valhalla"}
+export TILES_DIR=${TILES_DIR:-"${DATA_DIR}/tiles"}
+export TESTS_DIR=${TESTS_DIR:-"${DATA_DIR}/tests"}
+export EXTRACTS_DIR=${EXTRACTS_DIR:-"${DATA_DIR}/extracts"}
+export ELEVATION_DIR=${ELEVATION_DIR:-"${DATA_DIR}/elevation"}
+export TRANSIT_DIR=${TRANSIT_DIR:-"${DATA_DIR}/transit"}
+export CONF_FILE=${CONF_FILE:-"/conf/valhalla.json"}
+
+catch_exception() {
+  if [ $? != 0 ]; then
+    echo "[FAILURE] Detected non zero exit status while processing valhalla tiles!"
+    exit 1
+  fi
+}
+
+function mv_stamp() {
+  local b=$(basename ${1})
+  mv ${1} ${b%.*}_${2}.${b##*.}
+}
+
+function cp_stamp() {
+  local b=$(basename ${1})
+  cp -rp ${1} ${b%.*}_${2}.${b##*.}
+}
+
+function clean_s3() {
+  cutoff=$(date -d "-${2} days" +%s)
+  aws s3 ls ${1} | tail -n +2 | while read record; do
+    added=$(date -d "$(echo ${record} | awk '{print $1" "$2}')" +%s)
+    if [[ ${added} -lt ${cutoff} ]]; then
+      aws s3 rm ${1}$(echo ${record} | awk '{print $4}')
+    fi
+  done
+}
+
+function get_latest_transit() {
+  file=$(aws s3 ls ${1}transit_ | sort | tail -1)
+  file_name=$(echo ${file} | awk '{print $4}')
+  latest_upload=${1}${file_name}
+
+  #use the latest...if not already
+  if [ ! -f ${DATA_DIR}/${file_name} ]; then
+    # rm old tarball
+    rm -f ${DATA_DIR}/transit_*.tgz
+    aws s3 cp $latest_upload ${DATA_DIR}/${file_name}
+    # remove old data
+    rm -rf ${TRANSIT_DIR}
+    mkdir ${TRANSIT_DIR}
+    tar pxf ${DATA_DIR}/${file_name} -C ${TRANSIT_DIR}
+  fi
+}
+
+export PATH=$PATH:/usr/sbin:/usr/local/bin
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+MAX_CACHE_SIZE=`echo "$((1024 * 1024 * 1024))"`
+
+rm -rf ${TILES_DIR}
+mkdir -p ${TILES_DIR}
+catch_exception
+
+echo "[INFO] updating config."
+#config needs to be updated for cutting tiles.
+valhalla_build_config \
+      --mjolnir-tile-dir ${TILES_DIR} \
+      --mjolnir-max-cache-size ${MAX_CACHE_SIZE}
+      >${CONF_FILE}
+catch_exception
+
+# name the dir where this will go
+stamp=$(date +%Y_%m_%d-%H_%M_%S)
+
+# things we need to make if we dont have them
+extracts=$(find ${EXTRACTS_DIR} -type f -name "*.pbf")
+catch_exception
+admin_file=$(jq -r '.mjolnir.admin' ${CONF_FILE})
+catch_exception
+timezone_file=$(jq -r '.mjolnir.timezone' ${CONF_FILE})
+catch_exception
+if [ ! -e $admin_file ]; then
+  echo "[INFO] building admins."
+  valhalla_build_admins -c ${CONF_FILE} $(find ${EXTRACTS_DIR} -type f -name "*.pbf")
+  catch_exception
+fi
+if [ ! -e $timezone_file ]; then
+  echo "[INFO] building timezones."
+  valhalla_build_timezones ${CONF_FILE}
+  catch_exception
+fi
+
+#transit data
+if  [ -n "$S3_PATH" ]; then
+  echo "[INFO] getting transit data."
+  get_latest_transit ${S3_PATH}
+  catch_exception
+fi
+
+# cut tiles from the data
+echo "[INFO] building tiles."
+valhalla_build_tiles -c  ${CONF_FILE} $(find ${EXTRACTS_DIR} -type f -name "*.pbf")
+catch_exception
+rm -rf *.bin
+
+#basically only run if url exists
+if  [ -n "$TEST_FILE_URL" ]; then
+  echo "[INFO] running tests."
+  rm -rf ${TESTS_DIR}
+  mkdir -p ${TESTS_DIR}
+  # see if these tiles are any good
+  cp /scripts/test_tiles.sh ${TESTS_DIR}/test_tiles.sh
+  cp /scripts/batch.sh ${TESTS_DIR}/batch.sh
+  cp /scripts/run.sh ${TESTS_DIR}/run.sh
+  wget -q "${TEST_FILE_URL}" -O ${TESTS_DIR}/tests.txt; catch_exception
+  ${TESTS_DIR}/test_tiles.sh ${CONF_FILE} ${TESTS_DIR} tests.txt
+  catch_exception
+  echo "[SUCCESS] Tests passed."
+fi
+
+cur_extras_dir=${DATA_DIR}/extras_${stamp}
+mkdir -p ${cur_extras_dir}
+pushd ${cur_extras_dir}
+echo "[INFO] building connectivity."
+valhalla_build_connectivity -c ${CONF_FILE}
+catch_exception
+echo "[INFO] building stats."
+valhalla_build_statistics -c ${CONF_FILE}
+catch_exception
+echo "[INFO] exporting edges."
+valhalla_export_edges --config ${CONF_FILE} > edges_${stamp}.0sv
+catch_exception
+
+for f in connectivity*; do  mv_stamp $f ${stamp}; done
+mv_stamp statistics.sqlite ${stamp}
+mv_stamp maproulette_tasks.geojson ${stamp}
+cp_stamp ${TILES_DIR}/$(basename ${admin_file}) ${stamp}
+cp_stamp ${TILES_DIR}/$(basename ${timezone_file}) ${stamp}
+pushd ${TILES_DIR}
+find . | sort -n | tar -cf ${cur_extras_dir}/planet_${stamp}.tar --no-recursion -T -
+popd
+popd
+
+# do we want to send this update to s3 (do so in the background)
+if  [ -n "$S3_PATH" ]; then
+  {
+    echo "[INFO] uploading data."
+    #clean up s3 old files
+    clean_s3 ${S3_PATH} 30
+    #push up s3 new files
+    for f in ${cur_extras_dir}/*; do
+      aws s3 mv ${f} ${S3_PATH} --acl public-read
+    done
+    #signal other stacks to get new data
+    aws s3 ls ${S3_PATH}/planet_${stamp}.tar
+    #clean it up the new stuff
+    rm -rf ${cur_extras_dir}
+  }
+fi
+echo "[SUCCESS] Run complete.  Valhalla tile creation finished, exiting."

--- a/scripts/minutely_update.sh
+++ b/scripts/minutely_update.sh
@@ -1,0 +1,121 @@
+#!/bin/bash 
+#This script is based on the script located on github:
+#https://github.com/artemp/MapQuest-Render-Stack/blob/master/scripts/minutely_update.sh
+
+export DATA_DIR=${DATA_DIR:-"/data/valhalla"}
+export PLANET_FILE=${PLANET_FILE:-"planet-latest.osm.pbf"}
+export BASE_DIR=${BASE_DIR:-"${DATA_DIR}/extracts"}
+export WORKDIR_OSM=${WORKDIR_OSM:-"${BASE_DIR}/osmosis_work_dir.${PLANET_FILE}"}
+export CHANGESET_DIR=${CHANGESET_DIR:-"${WORKDIR_OSM}/minutely"}
+export URL=${URL:-"http://planet.us-east-1.mapzen.com/planet-latest.osm"}
+PLANET=$BASE_DIR/$PLANET_FILE
+
+OSMOSIS="/usr/bin/osmosis"
+export JAVACMD_OPTIONS="-Djava.io.tmpdir=${DATA_DIR}/temp"
+
+# check they're all present
+if [ ! -e $OSMOSIS ]; then
+  echo "[ERROR] osmosis ($OSMOSIS) not installed, but is required."
+  exit 1
+fi
+
+if [ ! -e /usr/bin/osmconvert ]; then
+  echo "[ERROR] osmconvert (/usr/bin/osmconvert) not installed, but is required."
+  exit 1
+fi
+
+osmosis_fetch_changeset() {
+  if [ ! -e $WORKDIR_OSM/state.txt ]; then
+    echo "[ERROR] Osmosis state file not found - has the state been correctly initialized?"
+    exit 1
+  fi
+  STATE_TIMESTAMP=$(grep '^timestamp=' $WORKDIR_OSM/state.txt | tail -n1 | cut -c 11-)
+  CURRENT_TIMESTAMP=$(date -u "+%Y-%m-%d_%H:%M:%S")
+  CHANGESET_FILE=$CHANGESET_DIR/changeset-$STATE_TIMESTAMP.ocs.gz
+
+  echo "$CURRENT_TIMESTAMP:Downloading changeset $STATE_TIMESTAMP"
+  cp $WORKDIR_OSM/state.txt $CHANGESET_DIR/state-$STATE_TIMESTAMP
+  $OSMOSIS --read-replication-interval workingDirectory=$WORKDIR_OSM \
+    --simplify-change --write-xml-change $CHANGESET_FILE
+}
+
+osmosis_cleanup() {
+  rm -f $CHANGESET_DIR/changeset-$STATE_TIMESTAMP.ocs.gz
+  rm -f $CHANGESET_DIR/state-$STATE_TIMESTAMP
+}
+
+update() {
+
+  osmosis_fetch_changeset
+
+  $OSMOSIS --rxc $CHANGESET_FILE --rb $PLANET --ac --wb $PLANET.new
+
+  # exit if osmosis fails
+  if [ $? -ne 0 ]; then
+    echo "[ERROR] failed to apply $CHANGESET_DIR/changeset-$STATE_TIMESTAMP.ocs.gz"
+    cp $CHANGESET_DIR/state-$STATE_TIMESTAMP $WORKDIR_OSM/state.txt
+    exit 1
+  else
+    echo "[SUCCESS] applied $CHANGESET_DIR/changeset-$STATE_TIMESTAMP.ocs.gz"
+    echo "[SUCCESS] Done"
+  fi
+
+  mv $PLANET.new $PLANET
+
+  echo "[INFO] running osmconvert $PLANET --out-statistics."
+  osmconvert $PLANET --out-statistics > $WORKDIR_OSM/current_stats.txt
+
+  osmosis_cleanup
+}
+
+initialize() {
+
+  # make the directories
+  rm -rf ${DATA_DIR}/temp
+  mkdir -p ${WORKDIR_OSM} ${CHANGESET_DIR} ${BASE_DIR} ${DATA_DIR}/temp
+
+  if [ ! -e $WORKDIR_OSM/state.txt ]; then
+
+    echo "[INFO] downloading osm data..."
+    wget --quiet -O ${BASE_DIR}/${PLANET_FILE} ${URL}.pbf
+
+    if [ $? -ne 0 ]; then
+      echo "[ERROR] Planet file failed to download - cannot initialize without this."
+      exit 1
+    fi
+
+    echo "[INFO] downloading osm md5sum..."
+    wget --quiet -O ${BASE_DIR}/${PLANET_FILE}.md5 ${URL}.pbf.md5
+    if [ $? -ne 0 ]; then
+      echo "[ERROR] Planet file md5sum failed to download - cannot initialize without this."
+      exit 1
+    fi
+
+    echo "[INFO] comparing md5sum values"
+    MD5=`cat ${PLANET_FILE}.md5 | awk '{print $1}'`
+    MD5_OUTPUT=`md5sum ${PLANET_FILE} | awk '{print $1}'`
+
+    if [ "${MD5}" != "${MD5_OUTPUT}" ]; then
+      echo "[ERROR] md5sums do not match."
+      exit 1
+    fi 
+
+    $OSMOSIS --read-replication-interval-init workingDirectory=$WORKDIR_OSM
+
+    baseUrl=http://planet.openstreetmap.org/replication/minute
+    replacement="s@^\(baseUrl\s*=\s*\).*\$@\1${baseUrl}@"
+    sed -i $replacement $WORKDIR_OSM/configuration.txt
+    sed -i "s/^\(maxInterval\s*=\s*\).*\$/\10/" $WORKDIR_OSM/configuration.txt
+
+    echo "[INFO] obtaining planet timestamp."
+    planet_timestamp=$(osmconvert $PLANET --out-timestamp)
+
+    wget "http://osm.personalwerk.de/replicate-sequences/?$planet_timestamp" -O $WORKDIR_OSM/state.txt;
+    cat $WORKDIR_OSM/state.txt
+
+  fi
+}
+
+initialize
+
+update

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Default config
+DEFAULT_CONFIG="../../conf/valhalla.json"
+
+function usage() {
+	echo "Usage: $0 path_test_request_file [conf=../../conf/valhalla.json]"
+        echo "Example: $0 requests/demo_routes.txt"
+	echo "Example: $0 requests/demo_routes.txt ~/valhalla.json"
+	exit 1
+}
+
+#set the input file and verify
+if [ -z "${1}" ]; then
+	echo "Missing path_test_request_file"
+	usage
+elif [ ! -f "${1}" ]; then
+	echo "Invalid path_test_request_file: ${1}"
+	usage
+else
+	INPUT="${1}"
+fi
+
+#set config variable to second argument or default
+CONF=${2:-${DEFAULT_CONFIG}}
+
+# verify config file exists
+if [ ! -f "${CONF}" ]; then
+	echo "Invalid config file: ${CONF}"
+	usage
+fi
+
+PATH=../:$PATH ./batch.sh ${INPUT} ${CONF}
+

--- a/scripts/test_tiles.sh
+++ b/scripts/test_tiles.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+CONF_FILE=$1
+DIR=$2
+TEST_FILE=$3
+
+pwd_dir=`pwd`
+cd ${DIR}
+
+#fill out the template with a date relative to now
+sed "s/DATE_TIME_TAG/`date --date='08:00 next Tue' +%Y-%m-%dT%H:%M`/g" ${DIR}/${TEST_FILE} > {$DIR}/transit_routes.txt
+route_count=$(wc -l ${DIR}/test_requests/${TEST_FILE} | awk '{print $1}')
+#RAD those tests
+./run.sh {$DIR}/transit_routes.txt ${CONF_FILE}
+#check whats going on
+succeed_count=`grep -ic success ${DIR}/results/*_transit_routes/statistics.csv`
+#this doesnt look good
+cd $pwd_dir
+if [[ ${succeed_count} != ${route_count} ]]; then
+  echo "[FAILURE] Tests failed."
+  exit 1
+fi
+rm -rf ${DIR}/results


### PR DESCRIPTION
@heffergm this is the init copy of scripts that we can use for creating routing tiles and then run associate segments on that data for open traffic.  I hope to reuse these for valhalla as well.  

`scripts/associate_segments.sh`  -- runs valhalla_associate_segments on valhalla data using the latest osmlr...thinking it can run once a week.
`scripts/batch.sh` -- used for testing valhalla tiles.  **Not needed for transit.**
`scripts/cut_tiles.sh` -- creates valhalla route tiles.  Should be set up to run forever via lamdba. 
`scripts/minutely_update.sh` -- Applies changesets to the latest planet.pbf file.  Should be set up to run forever via lamdba. 
`scripts/run.sh` -- used for testing valhalla tiles.  **Not needed for transit.**
`scripts/test_tiles.sh` -- used for testing valhalla tiles.  **Not needed for transit.**

We need to discuss as we are thinking that the results of minutely_update.sh should be saved in a mount point and cut_tiles will use that location to build valhalla tiles.  The same goes for associate_segments.sh...it will use a mount point to get the latest version of the valhalla tiles.  